### PR TITLE
IntSet with parallel exponentiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "bellman-bignat"
 version = "0.1.0"
 
 [dependencies]
+bincode = "1.2.1"
 derivative = "1.0.0"
 docopt = "1"
 fnv = "1.0.6"
@@ -22,3 +23,12 @@ sha2 = "0.8.0"
 quickcheck = "0.8"
 quickcheck_macros = "0.8"
 color-backtrace = { version = "0.2" }
+
+[dependencies.gmp-mpfr-sys]
+version = "1.2"
+default-features = false
+
+[dependencies.rug]
+version = "1.7"
+default-features = false
+features = ["integer", "serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,29 +6,23 @@ version = "0.1.0"
 bincode = "1.2.1"
 derivative = "1.0.0"
 docopt = "1"
+flate2 = "1.0"
 fnv = "1.0.6"
-rand = "0.4.5"
+gmp-mpfr-sys = { version = "1.2", default-features = false }
 hex = "0.3.2"
-time = "0.1"
 num-iter = "0.1"
 num-bigint = "0.2"
 num-traits = "0.2"
 num-integer = "0.1"
+rand = "0.4.5"
 rayon = "1.3"
+rug = { version = "1.7", default-features = false, features = ["integer", "serde", "rand"] }
 sapling-crypto = { package = "sapling-crypto_ce", git = "https://github.com/alex-ozdemir/sapling-crypto", branch = "bls12-poseidon" }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.8.0"
+time = "0.1"
 
 [dev-dependencies]
 quickcheck = "0.8"
 quickcheck_macros = "0.8"
 color-backtrace = { version = "0.2" }
-
-[dependencies.gmp-mpfr-sys]
-version = "1.2"
-default-features = false
-
-[dependencies.rug]
-version = "1.7"
-default-features = false
-features = ["integer", "serde", "rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ default-features = false
 [dependencies.rug]
 version = "1.7"
 default-features = false
-features = ["integer", "serde"]
+features = ["integer", "serde", "rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bellman-bignat"
 version = "0.1.0"
 
 [dependencies]
-bincode = "1.2.1"
+bincode = "1.2"
 derivative = "1.0.0"
 docopt = "1"
 flate2 = "1.0"
@@ -14,7 +14,7 @@ num-iter = "0.1"
 num-bigint = "0.2"
 num-traits = "0.2"
 num-integer = "0.1"
-rand = "0.4.5"
+rand = "0.4"
 rayon = "1.3"
 rug = { version = "1.7", default-features = false, features = ["integer", "serde", "rand"] }
 sapling-crypto = { package = "sapling-crypto_ce", git = "https://github.com/alex-ozdemir/sapling-crypto", branch = "bls12-poseidon" }

--- a/src/bin/serialize_bases.rs
+++ b/src/bin/serialize_bases.rs
@@ -1,0 +1,48 @@
+extern crate bellman_bignat;
+extern crate bincode;
+
+use bellman_bignat::set::int_set_par::PrecompBases;
+
+use std::env::args;
+
+const DFLT_LOG_BITS_PER_ELM: usize = 11;
+
+fn _usage(s: &str, argv0: &str) {
+    println!("Usage: {} <file> <max_expt> <ofile>{}", argv0, s);
+    std::process::exit(1);
+}
+
+fn main() {
+    let mut argv = args();
+    let argv0 = argv.next().unwrap();
+    if argv.len() < 3 {
+        _usage("", &argv0);
+    }
+
+    // handle arguments
+    let ifile = argv.next().unwrap();
+    let max_expt = argv.next().unwrap().parse::<usize>();
+    let ofile = argv.next().unwrap();
+    if max_expt.is_err() {
+        _usage("\nERROR: max_expt must be an integer", &argv0);
+    }
+    let max_expt = max_expt.unwrap();
+
+    let bits_per_elm = if argv.len() > 0 {
+        let bpe = argv.next().unwrap().parse::<usize>();
+        if bpe.is_err() {
+            DFLT_LOG_BITS_PER_ELM
+        } else {
+            bpe.unwrap()
+        }
+    } else {
+        DFLT_LOG_BITS_PER_ELM
+    };
+
+    let pcb = PrecompBases::from_file(&ifile, max_expt, bits_per_elm);
+    pcb.serialize(&ofile);
+
+    // read it back in just to double check
+    let test = PrecompBases::deserialize(&ofile);
+    assert_eq!(pcb, test);
+}

--- a/src/bin/serialize_bases.rs
+++ b/src/bin/serialize_bases.rs
@@ -1,7 +1,7 @@
 extern crate bellman_bignat;
 extern crate bincode;
 
-use bellman_bignat::set::int_set_par::PrecompBases;
+use bellman_bignat::set::int_set_par::ParExpComb;
 
 use std::env::args;
 
@@ -39,10 +39,10 @@ fn main() {
         DFLT_LOG_BITS_PER_ELM
     };
 
-    let pcb = PrecompBases::from_file(&ifile, max_expt, bits_per_elm);
+    let pcb = ParExpComb::from_file(&ifile, max_expt, bits_per_elm);
     pcb.serialize(&ofile);
 
     // read it back in just to double check
-    let test = PrecompBases::deserialize(&ofile);
+    let test = ParExpComb::deserialize(&ofile);
     assert_eq!(pcb, test);
 }

--- a/src/bin/serialize_bases.rs
+++ b/src/bin/serialize_bases.rs
@@ -5,10 +5,8 @@ use bellman_bignat::set::int_set_par::ParExpComb;
 
 use std::env::args;
 
-const DFLT_LOG_BITS_PER_ELM: usize = 11;
-
 fn _usage(s: &str, argv0: &str) {
-    println!("Usage: {} <file> <max_expt> <ofile>{}", argv0, s);
+    println!("Usage: {} <file> <log_spacing> <ofile>{}", argv0, s);
     std::process::exit(1);
 }
 
@@ -21,25 +19,14 @@ fn main() {
 
     // handle arguments
     let ifile = argv.next().unwrap();
-    let max_expt = argv.next().unwrap().parse::<usize>();
+    let log_spacing = argv.next().unwrap().parse::<usize>();
     let ofile = argv.next().unwrap();
-    if max_expt.is_err() {
-        _usage("\nERROR: max_expt must be an integer", &argv0);
+    if log_spacing.is_err() {
+        _usage("\nERROR: log_spacing must be an integer", &argv0);
     }
-    let max_expt = max_expt.unwrap();
+    let log_spacing = log_spacing.unwrap();
 
-    let bits_per_elm = if argv.len() > 0 {
-        let bpe = argv.next().unwrap().parse::<usize>();
-        if bpe.is_err() {
-            DFLT_LOG_BITS_PER_ELM
-        } else {
-            bpe.unwrap()
-        }
-    } else {
-        DFLT_LOG_BITS_PER_ELM
-    };
-
-    let pcb = ParExpComb::from_file(&ifile, max_expt, bits_per_elm);
+    let pcb = ParExpComb::from_file(&ifile, log_spacing);
     pcb.serialize(&ofile);
 
     // read it back in just to double check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(test)]
 
 extern crate test;
+extern crate bincode;
 extern crate fnv;
 extern crate num_iter;
 extern crate num_bigint;
@@ -12,6 +13,8 @@ extern crate rayon;
 extern crate sapling_crypto;
 #[macro_use]
 extern crate derivative;
+extern crate rug;
+extern crate serde;
 extern crate sha2;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate test;
 extern crate bincode;
+extern crate flate2;
 extern crate fnv;
 extern crate num_iter;
 extern crate num_bigint;

--- a/src/set/int_set.rs
+++ b/src/set/int_set.rs
@@ -1,11 +1,9 @@
 use num_bigint::BigUint;
-use rug::{Assign, Integer, ops::Pow};
 use sapling_crypto::bellman::pairing::Engine;
 use sapling_crypto::bellman::{ConstraintSystem, LinearCombination, SynthesisError};
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::ops::MulAssign;
 
 use group::{CircuitSemiGroup, SemiGroup};
 use mp::bignat::BigNat;
@@ -47,128 +45,6 @@ pub trait IntSet: Sized + Clone + Eq + Debug {
         }
         all_present
     }
-}
-
-/// ParallelExpSet uses precomputed tables to do deletions
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct ParallelExpSet<G: SemiGroup> {
-    group: G,
-    elements: BTreeMap<Integer, usize>,
-    digest: Option<G::Elem>,
-}
-
-impl<G: SemiGroup> IntSet for ParallelExpSet<G>
-where
-    G::Elem: Ord,
-{
-    type G = G;
-
-    fn new(group: G) -> Self {
-        Self {
-            digest: Some(group.generator()),
-            elements: BTreeMap::new(),
-            group,
-        }
-    }
-
-    fn new_with<I: IntoIterator<Item = BigUint>>(group: G, items: I) -> Self {
-        let mut this = Self::new(group);
-        this.insert_all(items);
-        this
-    }
-
-    fn insert(&mut self, n: BigUint) {
-        if let Some(ref mut d) = self.digest {
-            *d = self.group.power(d, &n);
-        }
-        *self.elements.entry(_from_biguint(&n)).or_insert(0) += 1;
-    }
-
-    fn remove(&mut self, n: &BigUint) -> bool {
-        let int_n = _from_biguint(n);
-        if let Some(count) = self.elements.get_mut(&int_n) {
-            *count -= 1;
-            if *count == 0 {
-                self.elements.remove(&int_n);
-            }
-            self.digest = None;
-            true
-        } else {
-            false
-        }
-    }
-
-    fn digest(&mut self) -> G::Elem {
-        use rayon::prelude::*;
-
-        if self.digest.is_none() {
-            // step 1: compute the exponent
-            let _expt = {
-                let mut tmp = Vec::with_capacity(self.elements.len() + 1);
-                tmp.par_extend(self.elements.par_iter().map(|(elem, ct)| Integer::from(elem.pow(*ct as u32))));
-                _parallel_multiply(&mut tmp);
-                tmp.pop().unwrap()
-            };
-
-            // step 2: split exponent into pieces
-            // for this, we need to know comb spacing
-        }
-        self.digest.clone().unwrap()
-    }
-
-    fn group(&self) -> &G {
-        &self.group
-    }
-}
-
-fn _from_biguint(n: &BigUint) -> Integer {
-    Integer::from_str_radix(n.to_str_radix(32).as_ref(), 32).unwrap()
-}
-
-fn _parallel_multiply(v: &mut Vec<Integer>) {
-    use rayon::prelude::*;
-
-    if v.len() % 2 == 1 {
-        v.push(Integer::from(1));
-    }
-
-    while v.len() > 1 {
-        // invariant: length of list is always even
-        assert!(v.len() % 2 == 0);
-
-        // split the list in half; multiply first half by second half in parallel
-        let split_point = v.len() / 2;
-        let (fst, snd) = v.split_at_mut(split_point);
-        fst.par_iter_mut().zip(snd).for_each(|(f, s)| f.mul_assign(s as &Integer));
-
-        // cut length of list in half, possibly padding with an extra '1'
-        if split_point != 1 && split_point % 2 == 1 {
-            v.truncate(split_point + 1);
-            v[split_point].assign(1);
-        } else {
-            v.truncate(split_point);
-        }
-    }
-
-    assert!(v.len() == 1);
-}
-
-#[test]
-fn pmul_test() {
-    const NELMS: usize = 2222;
-    use rug::rand::RandState;
-    let mut rnd = RandState::new();
-    let mut v = Vec::with_capacity(NELMS);
-    (0..NELMS).for_each(|_| v.push(Integer::from(Integer::random_bits(2048, &mut rnd))));
-
-    // sequential
-    let mut prod = Integer::from(1);
-    v.iter().for_each(|p| prod.mul_assign(p));
-
-    // parallel
-    _parallel_multiply(&mut v);
-
-    assert!(prod == v[0]);
 }
 
 /// An `NaiveExpSet` which computes products from scratch each time.

--- a/src/set/int_set.rs
+++ b/src/set/int_set.rs
@@ -1,9 +1,11 @@
 use num_bigint::BigUint;
+use rug::{Assign, Integer, ops::Pow};
 use sapling_crypto::bellman::pairing::Engine;
 use sapling_crypto::bellman::{ConstraintSystem, LinearCombination, SynthesisError};
 
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::ops::MulAssign;
 
 use group::{CircuitSemiGroup, SemiGroup};
 use mp::bignat::BigNat;
@@ -45,6 +47,128 @@ pub trait IntSet: Sized + Clone + Eq + Debug {
         }
         all_present
     }
+}
+
+/// ParallelExpSet uses precomputed tables to do deletions
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ParallelExpSet<G: SemiGroup> {
+    group: G,
+    elements: BTreeMap<Integer, usize>,
+    digest: Option<G::Elem>,
+}
+
+impl<G: SemiGroup> IntSet for ParallelExpSet<G>
+where
+    G::Elem: Ord,
+{
+    type G = G;
+
+    fn new(group: G) -> Self {
+        Self {
+            digest: Some(group.generator()),
+            elements: BTreeMap::new(),
+            group,
+        }
+    }
+
+    fn new_with<I: IntoIterator<Item = BigUint>>(group: G, items: I) -> Self {
+        let mut this = Self::new(group);
+        this.insert_all(items);
+        this
+    }
+
+    fn insert(&mut self, n: BigUint) {
+        if let Some(ref mut d) = self.digest {
+            *d = self.group.power(d, &n);
+        }
+        *self.elements.entry(_from_biguint(&n)).or_insert(0) += 1;
+    }
+
+    fn remove(&mut self, n: &BigUint) -> bool {
+        let int_n = _from_biguint(n);
+        if let Some(count) = self.elements.get_mut(&int_n) {
+            *count -= 1;
+            if *count == 0 {
+                self.elements.remove(&int_n);
+            }
+            self.digest = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn digest(&mut self) -> G::Elem {
+        use rayon::prelude::*;
+
+        if self.digest.is_none() {
+            // step 1: compute the exponent
+            let _expt = {
+                let mut tmp = Vec::with_capacity(self.elements.len() + 1);
+                tmp.par_extend(self.elements.par_iter().map(|(elem, ct)| Integer::from(elem.pow(*ct as u32))));
+                _parallel_multiply(&mut tmp);
+                tmp.pop().unwrap()
+            };
+
+            // step 2: split exponent into pieces
+            // for this, we need to know comb spacing
+        }
+        self.digest.clone().unwrap()
+    }
+
+    fn group(&self) -> &G {
+        &self.group
+    }
+}
+
+fn _from_biguint(n: &BigUint) -> Integer {
+    Integer::from_str_radix(n.to_str_radix(32).as_ref(), 32).unwrap()
+}
+
+fn _parallel_multiply(v: &mut Vec<Integer>) {
+    use rayon::prelude::*;
+
+    if v.len() % 2 == 1 {
+        v.push(Integer::from(1));
+    }
+
+    while v.len() > 1 {
+        // invariant: length of list is always even
+        assert!(v.len() % 2 == 0);
+
+        // split the list in half; multiply first half by second half in parallel
+        let split_point = v.len() / 2;
+        let (fst, snd) = v.split_at_mut(split_point);
+        fst.par_iter_mut().zip(snd).for_each(|(f, s)| f.mul_assign(s as &Integer));
+
+        // cut length of list in half, possibly padding with an extra '1'
+        if split_point != 1 && split_point % 2 == 1 {
+            v.truncate(split_point + 1);
+            v[split_point].assign(1);
+        } else {
+            v.truncate(split_point);
+        }
+    }
+
+    assert!(v.len() == 1);
+}
+
+#[test]
+fn pmul_test() {
+    const NELMS: usize = 2222;
+    use rug::rand::RandState;
+    let mut rnd = RandState::new();
+    let mut v = Vec::with_capacity(NELMS);
+    (0..NELMS).for_each(|_| v.push(Integer::from(Integer::random_bits(2048, &mut rnd))));
+
+    // sequential
+    let mut prod = Integer::from(1);
+    v.iter().for_each(|p| prod.mul_assign(p));
+
+    // parallel
+    _parallel_multiply(&mut v);
+
+    assert!(prod == v[0]);
 }
 
 /// An `NaiveExpSet` which computes products from scratch each time.

--- a/src/set/int_set_par.rs
+++ b/src/set/int_set_par.rs
@@ -241,7 +241,7 @@ where
             let _expt = {
                 let mut tmp = Vec::with_capacity(self.elements.len() + 1);
                 tmp.par_extend(self.elements.par_iter().map(|(elem, ct)| Integer::from(elem.pow(*ct as u32))));
-                _parallel_multiply(&mut tmp);
+                _parallel_product(&mut tmp);
                 tmp.pop().unwrap()
             };
 
@@ -260,7 +260,7 @@ fn _from_biguint(n: &BigUint) -> Integer {
     Integer::from_str_radix(n.to_str_radix(32).as_ref(), 32).unwrap()
 }
 
-fn _parallel_multiply(v: &mut Vec<Integer>) {
+fn _parallel_product(v: &mut Vec<Integer>) {
     use rayon::prelude::*;
 
     if v.len() % 2 == 1 {
@@ -335,7 +335,7 @@ mod tests {
         v.iter().for_each(|p| prod.mul_assign(p));
 
         // parallel
-        _parallel_multiply(&mut v);
+        _parallel_product(&mut v);
 
         assert!(prod == v[0]);
     }

--- a/src/set/int_set_par.rs
+++ b/src/set/int_set_par.rs
@@ -45,6 +45,7 @@ impl Default for PrecompBases {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl PrecompBases {
     // ** initialization and precomputation ** //
     /// read in a file with bases
@@ -171,12 +172,12 @@ fn _make_table(bases: &[Integer], modulus: &Integer) -> Vec<Integer> {
 
     // compute powerset of bases
     // for each element in bases
-    for bnum in 1..bases.len() {
+    for (bnum, base) in bases.iter().enumerate().skip(1) {
         let base_idx = 1 << bnum;
         // multiply bases[bnum] by the first base_idx elms of ret
         let (src, dst) = ret.split_at_mut(base_idx);
         for idx in 0..base_idx {
-            dst[idx].assign(&src[idx] * &bases[bnum]);
+            dst[idx].assign(&src[idx] * base);
             dst[idx].rem_assign(modulus);
         }
     }

--- a/src/set/int_set_par.rs
+++ b/src/set/int_set_par.rs
@@ -15,7 +15,7 @@ use super::int_set::IntSet;
 
 #[derive(Clone,Debug,Deserialize,Serialize,PartialEq,Eq)]
 /// A comb of precomputed powers of a base, plus optional precomputed tables of combinations
-pub struct PrecompBases {
+pub struct ParExpComb {
     /// The values
     bs: Vec<Integer>,
     m: Integer,
@@ -26,7 +26,7 @@ pub struct PrecompBases {
 }
 
 /// pcb[idx] is the idx'th precomputed table
-impl Index<usize> for PrecompBases {
+impl Index<usize> for ParExpComb {
     type Output = Vec<Integer>;
 
     fn index(&self, idx: usize) -> &Self::Output {
@@ -34,7 +34,7 @@ impl Index<usize> for PrecompBases {
     }
 }
 
-impl Default for PrecompBases {
+impl Default for ParExpComb {
     /// get default precomps
     fn default() -> Self {
         // XXX(HACK): we read from $CARGO_MANIFEST_DIR/lib/pcb_dflt
@@ -47,7 +47,7 @@ impl Default for PrecompBases {
 }
 
 #[allow(clippy::len_without_is_empty)]
-impl PrecompBases {
+impl ParExpComb {
     // ** initialization and precomputation ** //
     /// read in a file with bases
     pub fn from_file(filename: &str, log_max_size: usize, log_bits_per_elm: usize) -> Self {
@@ -195,7 +195,7 @@ pub struct ParallelExpSet<G: SemiGroup> {
     group: G,
     elements: BTreeMap<Integer, usize>,
     digest: Option<G::Elem>,
-    bases: Rc<PrecompBases>,    // NOTE: does this need to be Arc?
+    bases: Rc<ParExpComb>,    // NOTE: does this need to be Arc?
 }
 
 impl<G: SemiGroup> ParallelExpSet<G> {
@@ -213,7 +213,7 @@ where
     type G = G;
 
     fn new(group: G) -> Self {
-        let mut pc = PrecompBases::default();
+        let mut pc = ParExpComb::default();
         pc.make_tables(Self::N_PER_TABLE);
         Self {
             digest: None,   // start with None so that new_with builds in parallel by default
@@ -318,7 +318,7 @@ mod tests {
     fn precomp_table() {
         const NELMS: usize = 8;
 
-        let mut pc = PrecompBases::default();
+        let mut pc = ParExpComb::default();
         pc.make_tables(NELMS);
         assert!(pc.len() > 0);
 
@@ -350,12 +350,12 @@ mod tests {
     #[test]
     fn precomp_serdes() {
         let pc = {
-            let mut tmp = PrecompBases::default();
+            let mut tmp = ParExpComb::default();
             tmp.make_tables(4);
             tmp
         };
         pc.serialize("/tmp/serialized.gz");
-        let pc2 = PrecompBases::deserialize("/tmp/serialized.gz");
+        let pc2 = ParExpComb::deserialize("/tmp/serialized.gz");
         assert_eq!(pc, pc2);
     }
 

--- a/src/set/int_set_par.rs
+++ b/src/set/int_set_par.rs
@@ -440,6 +440,8 @@ mod tests {
         const NELMS: usize = 2222;
 
         let mut rnd = RandState::new();
+        _seed_rng(&mut rnd);
+
         let mut v = Vec::with_capacity(NELMS);
         (0..NELMS).for_each(|_| v.push(Integer::from(Integer::random_bits(2048, &mut rnd))));
 
@@ -464,11 +466,17 @@ mod tests {
         };
 
         let mut rnd = RandState::new();
-        let expt = Integer::from(Integer::random_bits(1 << LOG_EXPSIZE, &mut rnd));
+        _seed_rng(&mut rnd);
 
+        let expt = Integer::from(Integer::random_bits(1 << LOG_EXPSIZE, &mut rnd));
         let expect = Integer::from(pc.bases()[0].pow_mod_ref(&expt, pc.modulus()).unwrap());
         let result = pc.exp(&expt);
 
         assert_eq!(expect, result);
+    }
+
+    fn _seed_rng(rnd: &mut RandState) {
+        use rug::integer::Order;
+        rnd.seed(&Integer::from_digits(&rand::random::<[u64; 4]>()[..], Order::Lsf));
     }
 }

--- a/src/set/int_set_par.rs
+++ b/src/set/int_set_par.rs
@@ -127,17 +127,16 @@ impl ParExpComb {
         let modulus = &self.m;
         self.ts[0..n_tables].par_chunks(tables_per_chunk).enumerate().map(|(chunk_idx, ts)| {
             let mut acc = Integer::from(1);
-            let n_ts = ts.len();
             let chunk_offset = chunk_idx * tables_per_chunk * bits_per_table;
             for bdx in (0..bits_per_expt).rev() {
-                for tdx in 0..n_ts {
+                for (tdx, tsent) in ts.iter().enumerate() {
                     let mut val = 0u32;
                     for edx in 0..expts_per_table {
                         let bitnum = chunk_offset + tdx * bits_per_table + edx * bits_per_expt + bdx;
                         let bit = expt.get_bit(bitnum as u32) as u32;
                         val |= bit << edx;
                     }
-                    acc.mul_assign(&ts[tdx][val as usize]);
+                    acc.mul_assign(&tsent[val as usize]);
                     acc.rem_assign(modulus);
                 }
                 if bdx != 0 {

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -7,6 +7,7 @@ use hash::circuit::MaybeHashed;
 
 pub mod int_set;
 pub mod merkle;
+pub mod precomp;
 pub mod rsa;
 
 pub trait GenSet<F>

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -6,8 +6,8 @@ use CResult;
 use hash::circuit::MaybeHashed;
 
 pub mod int_set;
+pub mod int_set_par;
 pub mod merkle;
-pub mod precomp;
 pub mod rsa;
 
 pub trait GenSet<F>

--- a/src/set/precomp.rs
+++ b/src/set/precomp.rs
@@ -1,0 +1,130 @@
+use rug::{Assign, Integer};
+use serde::{Deserialize,Serialize};
+use std::convert::AsRef;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::ops::Index;
+
+#[derive(Debug,Deserialize,Serialize)]
+/// A comb of precomputed powers of a base, plus optional precomputed tables of combinations
+pub struct PrecompBases {
+    /// The values
+    bases: Vec<Integer>,
+    tables: Vec<Vec<Integer>>,
+}
+
+impl Index<usize> for PrecompBases {
+    type Output = Vec<Integer>;
+
+    fn index(&self, idx: usize) -> &Self::Output {
+        &self.tables[idx]
+    }
+}
+
+impl AsRef<[Integer]> for PrecompBases {
+    fn as_ref(&self) -> &[Integer] {
+        self.bases.as_ref()
+    }
+}
+
+impl PrecompBases {
+    pub fn from_file(filename: &str) -> Self {
+        Self {
+            bases: BufReader::new(File::open(filename).unwrap())
+                .lines()
+                .map(|x| Integer::from_str_radix(x.unwrap().as_ref(), 16).unwrap())
+                .collect(),
+
+            tables: Vec::new(),
+        }
+    }
+
+    pub fn make_tables(&mut self, n_per_table: usize) {
+        // parallel table building
+        use rayon::prelude::*;
+
+        // for each n bases, compute powerset of values
+        self.tables.clear();
+        self.tables.reserve(self.bases.len() / n_per_table + 1);
+        self.tables.par_extend(self.bases.par_chunks(n_per_table).map(|x| _make_table(x)));
+    }
+
+    pub fn n_tables(&self) -> usize {
+        self.tables.len()
+    }
+}
+
+fn _make_table(bases: &[Integer]) -> Vec<Integer> {
+    let mut ret = vec!(Integer::new(); 1 << bases.len());
+    // base case: 0 and 1
+    ret[0].assign(1);
+    ret[1].assign(&bases[0]);
+
+    // compute powerset of bases
+    // for each element in bases
+    for bnum in 1..bases.len() {
+        let base_idx = 1 << bnum;
+        // multiply bases[bnum] by the first base_idx elms of ret
+        let (src, dst) = ret.split_at_mut(base_idx);
+        for idx in 0..base_idx {
+            dst[idx].assign(&src[idx] * &bases[bnum]);
+        }
+    }
+
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+
+    #[test]
+    fn precomp_from_file() {
+        let pc = PrecompBases::from_file("/tmp/bases.txt");
+        assert!(pc.as_ref()[0] == 2);
+    }
+
+    #[test]
+    fn precomp_and_table() {
+        let n_elms = 8;
+        let mut pc = PrecompBases::from_file("/tmp/bases.txt");
+        pc.make_tables(n_elms);
+        assert!(pc.n_tables() > 0);
+
+        let num_tables = pc.as_ref().len() / n_elms +
+            if pc.as_ref().len() % n_elms == 1 {
+                1
+            } else {
+                0
+            };
+
+        assert!(pc.n_tables() == num_tables);
+        assert!(pc[0].len() == (1 << n_elms));
+    }
+
+    #[test]
+    fn precomp_serialize() {
+        let pc = {
+            let mut tmp = PrecompBases::from_file("/tmp/bases.txt");
+            tmp.make_tables(12);
+            tmp
+        };
+        let buf = bincode::serialize(&pc).unwrap();
+        {
+            let mut ofile = File::create("/tmp/serialized.txt").unwrap();
+            ofile.write_all(&buf[..]).unwrap();
+        }
+    }
+
+    #[test]
+    fn precomp_deserialize() {
+        let mut buffer = Vec::new();
+        {
+            let mut ifile = File::open("/tmp/deser_in.txt").unwrap();
+            ifile.read_to_end(&mut buffer).unwrap();
+        }
+        let pc : PrecompBases = bincode::deserialize(&buffer[..]).unwrap();
+        assert!(pc[0].len() == (1 << 12));
+    }
+}

--- a/src/util/gadget.rs
+++ b/src/util/gadget.rs
@@ -1,7 +1,7 @@
 use sapling_crypto::bellman::pairing::ff::ScalarEngine;
 use sapling_crypto::bellman::pairing::Engine;
 use sapling_crypto::bellman::{ConstraintSystem, LinearCombination, SynthesisError};
-use sapling_crypto::circuit::num::{AllocatedNum,Num};
+use sapling_crypto::circuit::num::AllocatedNum;
 
 use hash::circuit::CircuitHasher;
 


### PR DESCRIPTION
This PR implements parallel multi-exponentiation for IntSet using precomputation. Essentially all new code is in `src/set/int_set_par.rs`:

- `ParExpComb` is a struct that does parallel windowed multi-exponentiation using precomputed comb values. The window size is selectable, but must be a power of 2. Increasing window size gives roughly linear speedup, but memory cost (and precomputation time) increases exponentially with window size. 8 or 16 is about right.

- `ParallelExpSet` implements the `IntSet` interface and uses `ParExpComb` when recomputing the whole accumulator from scratch (e.g., upon removal). In addition, it provides a function, `clear_digest`, that forces a rebuild from scratch. This should be used before adding many values to the accumulator (here, "many" is, say, at least 1/4 of the current number of values in the accumulator).

Both of the above are based on [rug](https://crates.io/crates/rug) `Integer`s, which are GMP `mpz_t` values underneath.

One thing we might want to do in the future is change the `IntSet` interface to make it easier for `insert_all` to automatically decide whether to update or rebuild the digest. The reason this isn't so easy right now is that `insert_all` takes `<I: IntoIterator<Item = BigUint>>`, which doesn't provide a `len()` method---so we can't tell how many values we're being asked to add without, say, copying all of them into a `Vec`. It doesn't seem like this is much of an issue right now, since `new_with()` is **not** incremental in `ParallelExpSet` and generally we expect to be inserting far fewer elements than the number in the accumulator once it's built.

One thing that's missing right now is end-to-end tests of `ParallelExpSet`. I'll add some tests that check it against `NaiveExpSet`. Happy to hold off on the PR until that's done if you'd like.

Also, please let me know if you'd like me to squash the commits into one, etc.